### PR TITLE
runtime/panic_report: pipe panics & choose exit strategy

### DIFF
--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -713,6 +713,10 @@ func gopanic(e interface{}) {
 		}
 	}
 
+	// znly patch: from here, copy the panic output into a file.
+	// see src/runtime/panic_report.go
+	enableWritePanic()
+
 	// ran out of deferred calls - old-school panic now
 	// Because it is unsafe to call arbitrary user code after freezing
 	// the world, we call preprintpanics to invoke all necessary Error

--- a/src/runtime/panic_report.go
+++ b/src/runtime/panic_report.go
@@ -1,0 +1,59 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import "unsafe"
+
+// File descriptor of the panic file. If not set, equals to 0.
+var panicFd uintptr
+
+// see SetExitOnPanic. default value is `false`.
+var ExitOnPanic bool
+
+// true if a panic is happening
+var panicHappening bool
+
+// SetPanicFd sets the UNIX file descriptor to which the output of a panic will
+// be redirected. This is useful to persist panics (for mobile devices for
+// example).
+func SetPanicFd(fd uintptr) {
+	panicFd = fd
+}
+
+// SetExitOnPanic let the caller decides how the runtime should exit when a
+// non recovered panic happens.
+//
+// Setting `false` will make the runtime raise a signal to kill the process.
+// This is the default and vanilla behaviour.
+//
+// Setting `true` will make the runtime call `exit()` to stop the process. This
+// does not raise a signal.
+//
+// This function is useful to let the caller decides if a Go panic should be
+// caught or not by a global signal handler (e.g. a crash reporter's one).
+// Setting `true` will avoid a crash reporter to process a not-recovered Go
+// panic.
+func SetExitOnPanic(v bool) {
+	ExitOnPanic = v
+}
+
+func enableWritePanic() {
+	if panicFd == 0 && panicHappening == true {
+		return
+	}
+
+	panicHappening = true
+
+	// log current time. `print`s below will call at some point `writeErrPanic`.
+	sec, _ := walltime()
+	print("# time_sec=")
+	println(sec)
+}
+
+func writeErrPanic(b []byte) {
+	if panicHappening && panicFd != 0 {
+		write(panicFd, unsafe.Pointer(&b[0]), int32(len(b)))
+	}
+}

--- a/src/runtime/signal_unix.go
+++ b/src/runtime/signal_unix.go
@@ -425,6 +425,13 @@ func dieFromSignal(sig uint32) {
 	unblocksig(sig)
 	// Mark the signal as unhandled to ensure it is forwarded.
 	atomic.Store(&handlingSig[sig], 0)
+
+	// znly patch: check if flag `ExitOnPanic` is set, and if so, do not raise a
+	// signal.
+	if ExitOnPanic {
+		exit(2)
+	}
+
 	raise(sig)
 
 	// That should have killed us. On some systems, though, raise

--- a/src/runtime/write_err.go
+++ b/src/runtime/write_err.go
@@ -10,4 +10,5 @@ import "unsafe"
 
 func writeErr(b []byte) {
 	write(2, unsafe.Pointer(&b[0]), int32(len(b)))
+	writeErrPanic(b)
 }

--- a/src/runtime/write_err_android.go
+++ b/src/runtime/write_err_android.go
@@ -47,6 +47,7 @@ func writeErr(b []byte) {
 
 	// Write to stderr for command-line programs.
 	write(2, unsafe.Pointer(&b[0]), int32(len(b)))
+	writeErrPanic(b)
 
 	// Log format: "<header>\x00<message m bytes>\x00"
 	//


### PR DESCRIPTION
This adds a new method `runtimne.SetPanicFd` which sets the UNIX file
descriptor to which the output of a panic will be redirected. This is
useful to persist panics when Go is going to crash, to analyze it during
the next session.

This also adds `runtime.SetExitOnPanic` to let the caller decides how
the runtime should exit when a non recovred panic happens. Setting
`true` will make the runtime call `exit()` and not `raise()` to stop the
process. This is useful to let the caller decides if a Go panic should
be caught by a global signal handler set, for example, by a crash
reporter.